### PR TITLE
Add topv2 dataset

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -48,6 +48,7 @@ class BenchmarkArguments:
     random_shuffle: bool = True
     num_samples: Optional[int] = None
     n_shot: Optional[int] = 0
+    template: Optional[str] = None
 
 @dataclass
 class EvaluationExample:
@@ -177,6 +178,7 @@ def benchmark(
         n_shot=benchmark_arguments.n_shot,
         seed=seed,
         data_path=benchmark_arguments.data_path,
+        template=benchmark_arguments.template,
     )
     metrics = EvaluationMetrics.build_metrics()
     for i, example in enumerate(tqdm(evaluation_set)):

--- a/data.py
+++ b/data.py
@@ -30,6 +30,7 @@ class DatasetFormat:
     XSUM_SUMMARIZATION: str = "xsum_summarization"
     HUMAN_EVAL: str = "human_eval"
     CUSTOM_JSONL: str = "custom_jsonl"
+    TOP_v2: str = "top_v2"
 
 
 def LowercaseProcessingFunction(input: str) -> str:
@@ -133,6 +134,17 @@ def prepare_human_eval() -> List[EvaluationExample]:
         )
     return evaluation_data_points
 
+def prepare_top_v2() -> List[EvaluationExample]:
+    evaluation_data_points = []
+    for data_point in load_dataset('WillHeld/top_v2', split='test'):
+        evaluation_data_points.append(
+            EvaluationExample(
+                input=data_point["utterance"],
+                output=data_point["semantic_parse"],
+            )
+        )
+    return evaluation_data_points
+
 def prepare_custom(data_path: str, prompt_field: str = "prompt", response_field: str = "response") -> List[EvaluationExample]:
     evaluation_data_points = []
     for _, data_point in pd.read_json(data_path, lines=True).iterrows():
@@ -166,6 +178,8 @@ def get_data(
         evaluation_data_points = prepare_human_eval()
     elif dataset == DatasetFormat.CUSTOM_JSONL:
         evaluation_data_points = prepare_custom(data_path, prompt_field=prompt_field, response_field=response_field)
+    elif dataset == DatasetFormat.TOP_v2:
+        evaluation_data_points = prepare_top_v2()
     else:
         raise NotImplementedError(f"Unknown dataset format {dataset}")
 

--- a/data.py
+++ b/data.py
@@ -97,7 +97,7 @@ def prepare_cnn_dm_lm_format(template: str = None) -> List[EvaluationExample]:
     return evaluation_data_points
 
 
-def prepare_cnn_dm_summarization_format(n_shot: int = 0, seed: int = 42) -> List[EvaluationExample]:
+def prepare_cnn_dm_summarization_format(n_shot: int = 0, seed: int = 42, template: str = None) -> List[EvaluationExample]:
     prompt_shots = ""
     if n_shot > 0:
         prompt_keys=["article", "highlights"]
@@ -189,21 +189,23 @@ def get_data(
     seed: int = 42,
     prompt_field: str = "prompt",
     response_field: str = "response",
+    template: str = None
 ) -> List[EvaluationExample]:
     if dataset == DatasetFormat.CHAT_FORMAT:
-        evaluation_data_points = prepare_evaluation_examples_chat_format(data_path)
+        evaluation_data_points = prepare_evaluation_examples_chat_format(data_path, template=template)
     elif dataset == DatasetFormat.CNN_DM_SUMMARIZATION:
-        evaluation_data_points = prepare_cnn_dm_summarization_format(n_shot=n_shot, seed=seed)
+        evaluation_data_points = prepare_cnn_dm_summarization_format(n_shot=n_shot, seed=seed, template=template)
     elif dataset == DatasetFormat.XSUM_SUMMARIZATION:
-        evaluation_data_points = prepare_xsum_summarization_format(n_shot=n_shot, seed=seed)
+        evaluation_data_points = prepare_xsum_summarization_format(n_shot=n_shot, seed=seed, template=template)
     elif dataset == DatasetFormat.CNN_DM_LM:
-        evaluation_data_points = prepare_cnn_dm_lm_format()
+        evaluation_data_points = prepare_cnn_dm_lm_format(template)
     elif dataset == DatasetFormat.HUMAN_EVAL:
-        evaluation_data_points = prepare_human_eval()
+        evaluation_data_points = prepare_human_eval(template)
     elif dataset == DatasetFormat.CUSTOM_JSONL:
-        evaluation_data_points = prepare_custom(data_path, prompt_field=prompt_field, response_field=response_field)
+        evaluation_data_points = prepare_custom(data_path, prompt_field=prompt_field, 
+                                                response_field=response_field, template=template)
     elif dataset == DatasetFormat.TOP_V2:
-        evaluation_data_points = prepare_top_v2()
+        evaluation_data_points = prepare_top_v2(template)
     else:
         raise NotImplementedError(f"Unknown dataset format {dataset}")
 

--- a/data.py
+++ b/data.py
@@ -30,7 +30,7 @@ class DatasetFormat:
     XSUM_SUMMARIZATION: str = "xsum_summarization"
     HUMAN_EVAL: str = "human_eval"
     CUSTOM_JSONL: str = "custom_jsonl"
-    TOP_v2: str = "top_v2"
+    TOP_V2: str = "top_v2"
 
 
 def apply_template(message:str, template:str) -> str:
@@ -146,7 +146,7 @@ def prepare_xsum_summarization_format(n_shot: int = 0, seed: int = 42, template:
 def prepare_human_eval(template: str = None) -> List[EvaluationExample]:
     evaluation_data_points = []
     for data_point in load_dataset('openai_humaneval', split='test'):
-       prompt = apply_template(message=data_point["prompt"], template=template) 
+        prompt = apply_template(message=data_point["prompt"], template=template) 
         evaluation_data_points.append(
             EvaluationExample(
                 input=prompt,
@@ -202,7 +202,7 @@ def get_data(
         evaluation_data_points = prepare_human_eval()
     elif dataset == DatasetFormat.CUSTOM_JSONL:
         evaluation_data_points = prepare_custom(data_path, prompt_field=prompt_field, response_field=response_field)
-    elif dataset == DatasetFormat.TOP_v2:
+    elif dataset == DatasetFormat.TOP_V2:
         evaluation_data_points = prepare_top_v2()
     else:
         raise NotImplementedError(f"Unknown dataset format {dataset}")

--- a/data.py
+++ b/data.py
@@ -139,7 +139,7 @@ def prepare_top_v2() -> List[EvaluationExample]:
     for data_point in load_dataset('WillHeld/top_v2', split='test'):
         evaluation_data_points.append(
             EvaluationExample(
-                input=data_point["utterance"],
+               input= "[INST] " + data_point["utterance"] +  " [\INST]",
                 output=data_point["semantic_parse"],
             )
         )


### PR DESCRIPTION
Add TOPv2 dataset to the list of benchmarking datasets. 

To evaluate a model on TOPv2, run the following command:

```
$ torchrun benchmark.py --model facebook/layerskip-llama2-7B \
    --dataset top_v2 \
    --num_samples 100 \
    --generation_strategy self_speculative \
    --exit_layer 8 \
    --num_speculations 6 \
    --output_dir ./logs
```

To evaluate a model on TOPv2 using a template, run the following command:

```
$ torchrun benchmark.py --model facebook/layerskip-llama2-7B \
    --dataset top_v2 \
    --template "[INST] {message} [\INST]"
    --num_samples 100 \
    --generation_strategy self_speculative \
    --exit_layer 8 \
    --num_speculations 6 \
    --output_dir ./logs
```