### PR TITLE
throw error when user inputs unexpected cli argument

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -12,6 +12,7 @@ import random
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 import logging
+import sys
 
 import torch
 import transformers
@@ -23,7 +24,7 @@ from torchmetrics.text import BLEUScore, ROUGEScore, EditDistance
 from torcheval.metrics.aggregation.mean import Mean
 from torcheval.metrics.metric import Metric
 
-from data import get_data, LowercaseProcessingFunction
+from data import get_data, LowercaseProcessingFunction, get_valid_dataset_formats
 from generate import load_model_and_tokenizer, setup
 from utils import ROUGEScoreWrapper
 
@@ -230,17 +231,15 @@ def main(args: Arguments, benchmark_arguments: BenchmarkArguments, generation_co
 
 def process_cli_arguments() -> Tuple[arguments.Arguments, BenchmarkArguments, GenerationConfig]:
     parser = transformers.HfArgumentParser((arguments.Arguments, BenchmarkArguments, GenerationConfig))
-    (
-        general_arguments,
-        benchmark_arguments,
-        generation_config,
-        _remaining,
-    ) = parser.parse_args_into_dataclasses(return_remaining_strings=True)
+    general_arguments, benchmark_arguments, generation_config = parser.parse_args_into_dataclasses(return_remaining_strings=False)
 
+    assert benchmark_arguments.dataset in get_valid_dataset_formats(), f"{benchmark_arguments.dataset} is not a supported dataset!"
+    
     if general_arguments.model_args:
         general_arguments.model_args = simple_parse_args_string(general_arguments.model_args)
     else:
-        general_arguments.model_args = {}
+        general_arguments.model_arg = {}
+        
 
     return general_arguments, benchmark_arguments, generation_config
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -8,11 +8,9 @@
 import datetime
 import json
 import os
-import random
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 import logging
-import sys
 
 import torch
 import transformers

--- a/data.py
+++ b/data.py
@@ -33,6 +33,10 @@ class DatasetFormat:
     TOP_V2: str = "top_v2"
 
 
+def get_valid_dataset_formats():
+    # Extract the values of class attributes, excluding internal dunder methods
+    return [value for key, value in DatasetFormat.__dict__.items() if not key.startswith('__')]
+
 def apply_template(message:str, template:str) -> str:
     """
     Applies a template to a given message.

--- a/eval.py
+++ b/eval.py
@@ -435,8 +435,7 @@ def process_cli_arguments() -> Tuple[Arguments, EvalArguments, GenerationConfig]
         general_arguments,
         eval_arguments,
         generation_config,
-        _remaining,
-    ) = parser.parse_args_into_dataclasses(return_remaining_strings=True)
+    ) = parser.parse_args_into_dataclasses(return_remaining_strings=False)
 
     if general_arguments.model_args:
         general_arguments.model_args = simple_parse_args_string(general_arguments.model_args)

--- a/generate.py
+++ b/generate.py
@@ -147,8 +147,7 @@ def process_cli_arguments() -> Tuple[Arguments, GenerateArguments, GenerationCon
         general_arguments,
         generate_arguments,
         generation_config,
-        _remaining,
-    ) = parser.parse_args_into_dataclasses(return_remaining_strings=True)
+    ) = parser.parse_args_into_dataclasses(return_remaining_strings=False)
 
     if general_arguments.model_args:
         general_arguments.model_args = simple_parse_args_string(general_arguments.model_args)

--- a/sweep.py
+++ b/sweep.py
@@ -101,8 +101,7 @@ def process_cli_arguments() -> Tuple[arguments.Arguments, BenchmarkArguments, Ge
         benchmark_arguments,
         generation_config,
         sweep_arguments,
-        _remaining,
-    ) = parser.parse_args_into_dataclasses(return_remaining_strings=True)
+    ) = parser.parse_args_into_dataclasses(return_remaining_strings=False)
 
     if general_arguments.model_args:
         general_arguments.model_args = simple_parse_args_string(general_arguments.model_args)


### PR DESCRIPTION
Closes #18 

I use solution 1 which sets `return_remaining_strings` to False and removes `_remaining` from the returns tuple.

For benchmark.py script, I also check if the input dataset name matches the values in `DatasetFormat` in `data.py`

Example:
```
torchrun benchmark.py --model <MODEL_DIR> --dataset top_v2 
--num_samples 5  
--generation_strategy_self_speculative 
--exit_layer 8 
--num_speculations 6 
--output_dir ./logs/
```

Since generation_strategy_self_speculative is invalid option, the following error is thrown:

Traceback (most recent call last):
  File "/code/LayerSkip/benchmark.py", line 245, in <module>
    args, benchmark_arguments, generation_config = process_cli_arguments()
  File "/code/LayerSkip/benchmark.py", line 232, in process_cli_arguments
    general_arguments, benchmark_arguments, generation_config = parser.parse_args_into_dataclasses(return_remaining_strings=False)
  File "/.conda/envs/layer_skip/lib/python3.10/site-packages/transformers/hf_argparser.py", line 348, in parse_args_into_dataclasses
    raise ValueError(f"Some specified arguments are not used by the HfArgumentParser: {remaining_args}")
**ValueError: Some specified arguments are not used by the HfArgumentParser: ['--generation_strategy_self_speculative']**